### PR TITLE
Feature/static pages in sanity

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -3,36 +3,15 @@ import { Logo } from "~/components/Logo"
 import { Separator } from "~/components/ui/separator"
 import { Fragment } from "react"
 import { useRootLoaderData } from "~/lib/useRootLoaderData"
-
-const navLinks = [
-  {
-    title: "About",
-    url: "/about",
-  },
-  {
-    title: "Advertising",
-    url: "/advertising",
-  },
-  {
-    title: "Contact",
-    url: "/contact",
-  },
-  {
-    title: "Media",
-    url: "/media",
-  },
-  {
-    title: "Privacy Policy",
-    url: "/privacy",
-  },
-  {
-    title: "Terms of Use",
-    url: "/terms",
-  },
-]
+import { SupportedLanguages } from "~/i18n"
+import { useTranslation } from "react-i18next"
 
 export function Footer() {
-  const { locale } = useRootLoaderData()
+  const { footerLinks } = useRootLoaderData()
+  const {
+    i18n: { language },
+  } = useTranslation()
+  const currentLang = language as SupportedLanguages
 
   return (
     <footer className="border-t-4 border-slate-100 transition-colors duration-1000 ease-in-out dark:border-slate-800">
@@ -47,17 +26,17 @@ export function Footer() {
           className="flex flex-wrap items-center justify-center text-sm uppercase"
           role="menu"
         >
-          {navLinks.map((link, index) => (
-            <Fragment key={link.title}>
+          {footerLinks.map((link, index) => (
+            <Fragment key={link.title[currentLang]}>
               <Link
-                to={`/${locale}${link.url}`}
+                to={`/${currentLang}${link.route}`}
                 role="menuitem"
                 className="block px-8 py-4 tracking-widest"
               >
-                {link.title}
+                {link.title[currentLang]}
               </Link>
 
-              {index !== navLinks.length - 1 && (
+              {index !== footerLinks.length - 1 && (
                 <Separator orientation="vertical" className="h-6" />
               )}
             </Fragment>

--- a/app/components/PortableTextComponents.tsx
+++ b/app/components/PortableTextComponents.tsx
@@ -1,0 +1,72 @@
+import { Image } from "~/components/Image"
+import { ExternalLink } from "lucide-react"
+import { Separator } from "~/components/ui/separator"
+
+const PortableTextComponents = {
+  types: {
+    image: ({
+              value,
+            }: {
+      value: {
+        id: string
+        preview: string
+        attribution?: string
+        attributionUrl?: string
+        caption?: string
+        alt?: string
+      }
+    }) => {
+      return (
+        <figure className="full-bleed">
+          <Image
+            id={value.id}
+            width={640}
+            preview={value.preview}
+            loading="lazy"
+            className="w-full"
+            alt={value.alt ?? ""}
+          />
+          {value.attribution || value.caption ? (
+            <div className="holy-grail">
+              <figcaption className="flex justify-between">
+                {value.caption ? (
+                  <span className="flex-1 italic">{value.caption}</span>
+                ) : null}
+                {value.attribution ? (
+                  <span className="flex-1 text-right">
+                      Photo by{" "}
+                    {value.attributionUrl ? (
+                      <a href={value.attributionUrl}>
+                        {value.attribution}{" "}
+                        <ExternalLink className="inline h-4 w-4" />
+                      </a>
+                    ) : (
+                      value.attribution
+                    )}
+                    </span>
+                ) : null}
+              </figcaption>
+              <Separator className="my-8" />
+            </div>
+          ) : null}
+        </figure>
+      )
+    },
+  },
+
+  // marks: {
+  //   link: ({ children, value }) => {
+  //     const rel = !value.href.startsWith("/")
+  //       ? "noreferrer noopener"
+  //       : undefined
+  //     return (
+  //       <a href={value.href} rel={rel}>
+  //         {children}
+  //       </a>
+  //     )
+  //   },
+  // },
+}
+
+
+export default PortableTextComponents

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -33,6 +33,7 @@ import setLanguageCookie from "~/lib/setLanguageCookie"
 import { SupportedLanguages } from "~/i18n"
 import { sanitizeStrings } from "./lib/sanitizeStrings"
 import { client } from "./sanity/client"
+import { getFooterLinks, StaticPageRoute } from "~/sanity/queries/staticPages";
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: styles },
@@ -72,6 +73,7 @@ export type RootLoaderData = {
   query: string
   themePreference: string | undefined
   langPreference: SupportedLanguages | undefined
+  footerLinks: StaticPageRoute[]
 }
 
 export const loader: LoaderFunction = async ({ request }) => {
@@ -108,6 +110,7 @@ export const loader: LoaderFunction = async ({ request }) => {
   }))
 
   const categories = await getCategories(client, locale)
+  const footerLinks = await getFooterLinks(client, locale)
 
   return json<RootLoaderData>(
     {
@@ -121,6 +124,7 @@ export const loader: LoaderFunction = async ({ request }) => {
       query: HOME_QUERY,
       themePreference,
       langPreference,
+      footerLinks,
     },
     {
       headers,

--- a/app/routes/$lang.$slug.tsx
+++ b/app/routes/$lang.$slug.tsx
@@ -20,10 +20,10 @@ import { HeroImage } from "~/components/HeroImage"
 import { Separator } from "~/components/ui/separator"
 import invariant from "tiny-invariant"
 import isLangSupportedLang from "~/sanity/queries/isLangSupportedLang"
-import { Image } from "~/components/Image"
 import { useOtherLanguage } from "~/lib/useOtherLanguage"
 import { UserMediaObject } from "~/components/UserMediaObject"
 import { useTranslate } from "~/lib/useTranslate"
+import PortableTextComponents from "~/components/PortableTextComponents"
 
 export const meta: MetaFunction<
   typeof loader,
@@ -88,73 +88,6 @@ export default function Slug() {
   const otherLanguage = useOtherLanguage()
 
   const translationUrl = `/${otherLanguage}/${post.slug[otherLanguage]}`
-
-  // TODO: move the components and PortableText to a separate file
-  const myPortableTextComponents = {
-    types: {
-      image: ({
-        value,
-      }: {
-        value: {
-          id: string
-          preview: string
-          attribution?: string
-          attributionUrl?: string
-          caption?: string
-          alt?: string
-        }
-      }) => {
-        return (
-          <figure className="full-bleed">
-            <Image
-              id={value.id}
-              width={640}
-              preview={value.preview}
-              loading="lazy"
-              className="w-full"
-              alt={value.alt ?? ""}
-            />
-            {value.attribution || value.caption ? (
-              <div className="holy-grail">
-                <figcaption className="flex justify-between">
-                  {value.caption ? (
-                    <span className="flex-1 italic">{value.caption}</span>
-                  ) : null}
-                  {value.attribution ? (
-                    <span className="flex-1 text-right">
-                      Photo by{" "}
-                      {value.attributionUrl ? (
-                        <a href={value.attributionUrl}>
-                          {value.attribution}{" "}
-                          <ExternalLink className="inline h-4 w-4" />
-                        </a>
-                      ) : (
-                        value.attribution
-                      )}
-                    </span>
-                  ) : null}
-                </figcaption>
-                <Separator className="my-8" />
-              </div>
-            ) : null}
-          </figure>
-        )
-      },
-    },
-
-    // marks: {
-    //   link: ({ children, value }) => {
-    //     const rel = !value.href.startsWith("/")
-    //       ? "noreferrer noopener"
-    //       : undefined
-    //     return (
-    //       <a href={value.href} rel={rel}>
-    //         {children}
-    //       </a>
-    //     )
-    //   },
-    // },
-  }
 
   return (
     <Layout translationUrl={translationUrl}>
@@ -229,7 +162,7 @@ export default function Slug() {
         <div className="holy-grail prose prose-xl prose-slate mx-4 my-24 max-w-none dark:prose-invert lg:prose-2xl prose-a:text-red-600 hover:prose-a:text-red-500">
           <PortableText
             value={post.body}
-            components={myPortableTextComponents}
+            components={PortableTextComponents}
           />
         </div>
       </article>

--- a/app/routes/$lang.about.tsx
+++ b/app/routes/$lang.about.tsx
@@ -2,20 +2,35 @@ import { Layout } from "~/components/Layout"
 import { Typography } from "~/components/Typography"
 import isLangSupportedLang from "~/sanity/queries/isLangSupportedLang"
 import { json, LoaderFunction } from "@remix-run/node"
+import { getStaticPageByRoute, StaticPage } from "~/sanity/queries/staticPages"
+import { client } from "~/sanity/client"
+import { useLoaderData } from "@remix-run/react"
+import { PortableText } from "@portabletext/react"
+import PortableTextComponents from "~/components/PortableTextComponents"
+import { useOtherLanguage } from "~/lib/useOtherLanguage"
+
+type StaticPageLoaderData = {
+  staticPage: StaticPage
+}
 
 export const loader: LoaderFunction = async ({ params }) => {
   isLangSupportedLang(params.lang)
 
-  return json({}, { status: 200 })
+  const staticPage = await getStaticPageByRoute(client, params.lang, "/about")
+
+  return json({ staticPage }, { status: 200 })
 }
 
 const Privacy = () => {
+  const { staticPage } = useLoaderData() as StaticPageLoaderData
+
   return (
-    <Layout useMargins>
-      <Typography.H1>About Us</Typography.H1>
-      <Typography.TextSmall>
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam
-      </Typography.TextSmall>
+    <Layout useMargins translationUrl={`/${useOtherLanguage()}/about`}>
+      <Typography.H1>{staticPage.title[staticPage.language]}</Typography.H1>
+      <PortableText
+        value={staticPage.body[staticPage.language]}
+        components={PortableTextComponents}
+      />
     </Layout>
   )
 }

--- a/app/routes/$lang.advertising.tsx
+++ b/app/routes/$lang.advertising.tsx
@@ -2,20 +2,39 @@ import { Layout } from "~/components/Layout"
 import { Typography } from "~/components/Typography"
 import isLangSupportedLang from "~/sanity/queries/isLangSupportedLang"
 import { json, LoaderFunction } from "@remix-run/node"
+import { getStaticPageByRoute, StaticPage } from "~/sanity/queries/staticPages"
+import { client } from "~/sanity/client"
+import { useLoaderData } from "@remix-run/react"
+import { PortableText } from "@portabletext/react"
+import PortableTextComponents from "~/components/PortableTextComponents"
+import { useOtherLanguage } from "~/lib/useOtherLanguage"
+
+type StaticPageLoaderData = {
+  staticPage: StaticPage
+}
 
 export const loader: LoaderFunction = async ({ params }) => {
   isLangSupportedLang(params.lang)
 
-  return json({}, { status: 200 })
+  const staticPage = await getStaticPageByRoute(
+    client,
+    params.lang,
+    "/advertising"
+  )
+
+  return json({ staticPage }, { status: 200 })
 }
 
 const Privacy = () => {
+  const { staticPage } = useLoaderData() as StaticPageLoaderData
+
   return (
-    <Layout useMargins>
-      <Typography.H1>Advertising</Typography.H1>
-      <Typography.TextSmall>
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam
-      </Typography.TextSmall>
+    <Layout useMargins translationUrl={`/${useOtherLanguage()}/advertising`}>
+      <Typography.H1>{staticPage.title[staticPage.language]}</Typography.H1>
+      <PortableText
+        value={staticPage.body[staticPage.language]}
+        components={PortableTextComponents}
+      />
     </Layout>
   )
 }

--- a/app/routes/$lang.contact.tsx
+++ b/app/routes/$lang.contact.tsx
@@ -2,20 +2,35 @@ import { Layout } from "~/components/Layout"
 import { Typography } from "~/components/Typography"
 import isLangSupportedLang from "~/sanity/queries/isLangSupportedLang"
 import { json, LoaderFunction } from "@remix-run/node"
+import { getStaticPageByRoute, StaticPage } from "~/sanity/queries/staticPages"
+import { client } from "~/sanity/client"
+import { useLoaderData } from "@remix-run/react"
+import { PortableText } from "@portabletext/react"
+import PortableTextComponents from "~/components/PortableTextComponents"
+import { useOtherLanguage } from "~/lib/useOtherLanguage"
+
+type StaticPageLoaderData = {
+  staticPage: StaticPage
+}
 
 export const loader: LoaderFunction = async ({ params }) => {
   isLangSupportedLang(params.lang)
 
-  return json({}, { status: 200 })
+  const staticPage = await getStaticPageByRoute(client, params.lang, "/contact")
+
+  return json({ staticPage }, { status: 200 })
 }
 
 const Privacy = () => {
+  const { staticPage } = useLoaderData() as StaticPageLoaderData
+
   return (
-    <Layout useMargins>
-      <Typography.H1>Contact</Typography.H1>
-      <Typography.TextSmall>
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam
-      </Typography.TextSmall>
+    <Layout useMargins translationUrl={`/${useOtherLanguage()}/contact`}>
+      <Typography.H1>{staticPage.title[staticPage.language]}</Typography.H1>
+      <PortableText
+        value={staticPage.body[staticPage.language]}
+        components={PortableTextComponents}
+      />
     </Layout>
   )
 }

--- a/app/routes/$lang.media.tsx
+++ b/app/routes/$lang.media.tsx
@@ -2,20 +2,35 @@ import { Layout } from "~/components/Layout"
 import { Typography } from "~/components/Typography"
 import isLangSupportedLang from "~/sanity/queries/isLangSupportedLang"
 import { json, LoaderFunction } from "@remix-run/node"
+import { getStaticPageByRoute, StaticPage } from "~/sanity/queries/staticPages"
+import { client } from "~/sanity/client"
+import { useLoaderData } from "@remix-run/react"
+import { PortableText } from "@portabletext/react"
+import PortableTextComponents from "~/components/PortableTextComponents"
+import { useOtherLanguage } from "~/lib/useOtherLanguage"
+
+type StaticPageLoaderData = {
+  staticPage: StaticPage
+}
 
 export const loader: LoaderFunction = async ({ params }) => {
   isLangSupportedLang(params.lang)
 
-  return json({}, { status: 200 })
+  const staticPage = await getStaticPageByRoute(client, params.lang, "/media")
+
+  return json({ staticPage }, { status: 200 })
 }
 
 const Privacy = () => {
+  const { staticPage } = useLoaderData() as StaticPageLoaderData
+
   return (
-    <Layout useMargins>
-      <Typography.H1>Media</Typography.H1>
-      <Typography.TextSmall>
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam
-      </Typography.TextSmall>
+    <Layout useMargins translationUrl={`/${useOtherLanguage()}/media`}>
+      <Typography.H1>{staticPage.title[staticPage.language]}</Typography.H1>
+      <PortableText
+        value={staticPage.body[staticPage.language]}
+        components={PortableTextComponents}
+      />
     </Layout>
   )
 }

--- a/app/routes/$lang.privacy.tsx
+++ b/app/routes/$lang.privacy.tsx
@@ -2,20 +2,35 @@ import { Layout } from "~/components/Layout"
 import { Typography } from "~/components/Typography"
 import isLangSupportedLang from "~/sanity/queries/isLangSupportedLang"
 import { json, LoaderFunction } from "@remix-run/node"
+import { getStaticPageByRoute, StaticPage } from "~/sanity/queries/staticPages"
+import { client } from "~/sanity/client"
+import { useLoaderData } from "@remix-run/react"
+import { PortableText } from "@portabletext/react"
+import PortableTextComponents from "~/components/PortableTextComponents"
+import { useOtherLanguage } from "~/lib/useOtherLanguage"
+
+type StaticPageLoaderData = {
+  staticPage: StaticPage
+}
 
 export const loader: LoaderFunction = async ({ params }) => {
   isLangSupportedLang(params.lang)
 
-  return json({}, { status: 200 })
+  const staticPage = await getStaticPageByRoute(client, params.lang, "/privacy")
+
+  return json({ staticPage }, { status: 200 })
 }
 
 const Privacy = () => {
+  const { staticPage } = useLoaderData() as StaticPageLoaderData
+
   return (
-    <Layout useMargins>
-      <Typography.H1>Privacy Policy</Typography.H1>
-      <Typography.TextSmall>
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam
-      </Typography.TextSmall>
+    <Layout useMargins translationUrl={`/${useOtherLanguage()}/privacy`}>
+      <Typography.H1>{staticPage.title[staticPage.language]}</Typography.H1>
+      <PortableText
+        value={staticPage.body[staticPage.language]}
+        components={PortableTextComponents}
+      />
     </Layout>
   )
 }

--- a/app/routes/$lang.terms.tsx
+++ b/app/routes/$lang.terms.tsx
@@ -2,20 +2,35 @@ import { Layout } from "~/components/Layout"
 import { Typography } from "~/components/Typography"
 import isLangSupportedLang from "~/sanity/queries/isLangSupportedLang"
 import { json, LoaderFunction } from "@remix-run/node"
+import { getStaticPageByRoute, StaticPage } from "~/sanity/queries/staticPages"
+import { client } from "~/sanity/client"
+import { useLoaderData } from "@remix-run/react"
+import { PortableText } from "@portabletext/react"
+import PortableTextComponents from "~/components/PortableTextComponents"
+import { useOtherLanguage } from "~/lib/useOtherLanguage"
+
+type StaticPageLoaderData = {
+  staticPage: StaticPage
+}
 
 export const loader: LoaderFunction = async ({ params }) => {
   isLangSupportedLang(params.lang)
 
-  return json({}, { status: 200 })
+  const staticPage = await getStaticPageByRoute(client, params.lang, "/terms")
+
+  return json({ staticPage }, { status: 200 })
 }
 
 const Privacy = () => {
+  const { staticPage } = useLoaderData() as StaticPageLoaderData
+
   return (
-    <Layout useMargins>
-      <Typography.H1>Terms of Use</Typography.H1>
-      <Typography.TextSmall>
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam
-      </Typography.TextSmall>
+    <Layout useMargins translationUrl={`/${useOtherLanguage()}/terms`}>
+      <Typography.H1>{staticPage.title[staticPage.language]}</Typography.H1>
+      <PortableText
+        value={staticPage.body[staticPage.language]}
+        components={PortableTextComponents}
+      />
     </Layout>
   )
 }

--- a/app/sanity/queries/staticPages.ts
+++ b/app/sanity/queries/staticPages.ts
@@ -1,0 +1,67 @@
+import groq from "groq"
+import type { SanityStegaClient } from "@sanity/client/stega"
+import { PortableTextBlock } from "@sanity/types"
+import { LocalizedString } from "~/sanity/queries/shared"
+
+export async function getStaticPageByRoute(
+  client: SanityStegaClient,
+  language: string | undefined,
+  route: string
+): Promise<StaticPage | null> {
+  return await client.fetch<StaticPage | null>(staticPageBySlugQuery, {
+    route,
+    language,
+  })
+}
+
+export const staticPageBySlugQuery = groq`*[_type == "staticPageType" && route == $route][0]{
+  _id,
+  _createdAt,
+  "title": {
+    "en": title.en,
+    "fr": title.fr,
+  },
+  route,
+  "body": {
+    "en": body.en,
+    "fr": body.fr,
+  },
+  "language": $language,
+}`
+
+// get all staticPages where isFooterLink is true
+const footerLinksQuery = groq`*[_type == "staticPageType" && isFooterLink == true]{
+  _id,
+  _createdAt,
+   route,
+  "language": $language,
+  "title": {
+    "en": title.en,
+    "fr": title.fr,
+  },
+}`
+
+export async function getFooterLinks(
+  client: SanityStegaClient,
+  language: string | undefined
+): Promise<StaticPageRoute[]> {
+  return await client.fetch<StaticPage[]>(footerLinksQuery, {
+    language,
+  })
+}
+
+export type StaticPageRoute = {
+  _type: "staticPageType"
+  _id: string
+  _createdAt: string
+  route: string
+  language: "en" | "fr"
+  title: LocalizedString
+}
+
+export type StaticPage = {
+  body: {
+    en: PortableTextBlock[]
+    fr: PortableTextBlock[]
+  }
+} & StaticPageRoute

--- a/app/sanity/schema/index.ts
+++ b/app/sanity/schema/index.ts
@@ -8,6 +8,8 @@ import { localeText } from "~/sanity/schema/localeText"
 import { postType } from "~/sanity/schema/post"
 import { recordType } from "~/sanity/schema/recordType"
 import { tagType } from "~/sanity/schema/tag"
+import { staticPageType } from "~/sanity/schema/staticPage"
+import { localeBlockContentType } from "~/sanity/schema/localeBlockContent";
 
 export default [
   authorType,
@@ -20,4 +22,6 @@ export default [
   postType,
   recordType,
   tagType,
+  staticPageType,
+  localeBlockContentType,
 ]

--- a/app/sanity/schema/localeBlockContent.ts
+++ b/app/sanity/schema/localeBlockContent.ts
@@ -1,0 +1,13 @@
+import { defineType } from "sanity";
+import { supportedLanguages } from "~/sanity/schema/language";
+
+export const localeBlockContentType = defineType({
+  title: "Localized Block Content",
+  name: "localeBlockContentType",
+  type: "object",
+  fields: supportedLanguages.map((lang) => ({
+    title: lang.title,
+    name: lang.id,
+    type: "blockContentType",
+  })),
+})

--- a/app/sanity/schema/staticPage.ts
+++ b/app/sanity/schema/staticPage.ts
@@ -1,0 +1,40 @@
+import { defineField, defineType } from "sanity"
+
+export const staticPageType = defineType({
+  name: "staticPageType",
+  title: "Static Page",
+  type: "document",
+  fields: [
+    defineField({
+      name: "title",
+      title: "Static Page Heading",
+      type: "localeString",
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "route",
+      title: "Route",
+      type: "string",
+      validation: (Rule) => Rule.required().regex(/^\/.*/),
+    }),
+    defineField({
+      name: "isFooterLink",
+      title: "Show Link in Footer",
+      type: "boolean",
+      initialValue: true,
+    }),
+    defineField({
+      name: "body",
+      title: "Body",
+      type: "localeBlockContentType",
+      validation: (Rule) => Rule.required(),
+    }),
+  ],
+
+  preview: {
+    select: {
+      title: "title.en",
+      body: "body",
+    },
+  },
+})

--- a/app/sanity/structure/index.ts
+++ b/app/sanity/structure/index.ts
@@ -28,6 +28,9 @@ export const structure: StructureResolver = (S) =>
       S.documentTypeListItem("categoryType").title("Categories").icon(Folder),
       S.divider(),
       S.documentTypeListItem("tagType").title("Tags").icon(Tags),
+      S.divider(),
+      S.documentTypeListItem("staticPageType").title("Static Pages").icon(Folder),
+      S.divider(),
     ])
 
 export const defaultDocumentNode: DefaultDocumentNodeResolver = (

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -5,5 +5,11 @@
   "currentLanguage": "English",
   "toggleTheme": "Change theme",
   "viewAll": "View all",
-  "postsTagged": "Posts Tagged"
+  "postsTagged": "Posts Tagged",
+  "about": "About",
+  "advertising": "Advertising",
+  "contact": "Contact",
+  "media": "Media",
+  "privacyPolicy": "Privacy Policy",
+  "terms": "Terms of Use"
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -5,5 +5,11 @@
   "currentLanguage": "Français",
   "toggleTheme": "Changer le thème",
   "viewAll": "Voir tout",
-  "postsTagged": "Articles Tagués"
+  "postsTagged": "Articles Tagués",
+  "about": "À propos",
+  "advertising": "Publicité",
+  "contact": "Contact",
+  "media": "Médias",
+  "privacyPolicy": "Politique de Confidentialité",
+  "terms": "Conditions d'utilisation"
 }


### PR DESCRIPTION
- Drive the static footer links via sanity. 
- allow the links to be hidden with `isFooterLink` boolean. 
- setup localeBlockContent - which we can port back to posts, I think that this'll be an interesting thing to figure out how to do migrations without killing past data...